### PR TITLE
Add support for deep property selectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ gulp.task('blog-posts', function() {
   gulp.src('./posts/*.md')
     .pipe(frontMatter({ // optional configuration
       property: 'frontMatter', // property added to file object
+                               // also works with deep property selectors
+                               // e.g., 'data.foo.bar'
       remove: true // should we remove front-matter header?
     }))
     .pipe(…) // you may want to take a look at gulp-marked at this point

--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ var PluginError = require('gulp-util').PluginError;
 var Transform = require('readable-stream/transform');
 var tryit = require('tryit');
 var VinylBufferStream = require('vinyl-bufferstream');
+var objectPath = require('object-path');
 
 module.exports = function gulpFrontMatter(options) {
   options = options || {};
@@ -37,7 +38,7 @@ module.exports = function gulpFrontMatter(options) {
             return;
           }
 
-          file[property] = content.attributes;
+          objectPath.set(file, property, content.attributes);
           if (options.remove !== false) {
             done(null, new Buffer(content.body));
             return;

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   "dependencies": {
     "front-matter": "^1.0.0",
     "gulp-util": "^3.0.6",
+    "object-path": "^0.9.2",
     "readable-stream": "^2.0.1",
     "tryit": "^1.0.1",
     "vinyl-bufferstream": "^1.0.1"

--- a/test.js
+++ b/test.js
@@ -6,7 +6,7 @@ var stringToStream = require('from2-string');
 var test = require('tape');
 
 test('gulp-front-matter', function(t) {
-  t.plan(16);
+  t.plan(18);
 
   t.equal(frontMatter.name, 'gulpFrontMatter', 'should have a function name.');
 
@@ -123,4 +123,24 @@ test('gulp-front-matter', function(t) {
     /.*is not a string.*must be a string/,
     'should throw a plugin error when `property` option is not a string.'
   );
+
+  var deepTest = frontMatter({property: 'data.foo'})
+  .on('error', t.fail)
+  .on('data', function(file) {
+    t.deepEqual(
+      file.data.foo,
+      [false],
+      'should change deep properties using `property.subproperty` option.'
+    );
+    t.notOk(
+      'frontMatter' in file,
+      'should not change `frontMatter` property when `property` option isn\'t the default value.'
+    );
+  });
+  var deepFile = new File({contents: new Buffer('---\n- false\n---\nHi')});
+  deepFile.data = {
+    asd: 'qwe',
+    foo: 'bar'
+  };
+  deepTest.end(deepFile);
 });


### PR DESCRIPTION
Hello!

I'd like to use gulp-front-matter in conjunction with gulp-data but merging the front matter under the same property where I store my data from gulp-data would cause it to be overwritten. I also understand that gulp-front-matter can't just extend the target property (assuming it's an object) instead of setting it because the front matter can be anything. This *could* be solved by another separate gulp-data call where I merge my front matter under the data property somewhere but that is just inconvenient. Hence my solution: set the arbitrary front matter under a deep key, e.g., data.frontMatter and everyone is happy.

Please consider merging this and publishing to npm... I didn't find any contribution guidelines, but I ran the lint/tests/coverage and everything seems fine.